### PR TITLE
TexTransToolのExternalToolAsLayerに対応

### DIFF
--- a/Editor/Models/ExtendedRenderTexture.cs
+++ b/Editor/Models/ExtendedRenderTexture.cs
@@ -25,10 +25,10 @@ namespace net.puk06.ColorChanger.Models
 
         /// <summary>
         /// Texture2D のサイズの大きさの ExtendedRenderTexture を Initialize します。Createはこの時点では実行されません。
-        /// 作成時、中身はコピーされません。中身をコピーしたい場合は <see cref="Create(Texture2D)"/> を使ってください。
+        /// 作成時、中身はコピーされません。中身をコピーしたい場合は <see cref="Create(Texture)"/> を使ってください。
         /// </summary>
         /// <param name="texture"></param>
-        public ExtendedRenderTexture(Texture2D texture)
+        public ExtendedRenderTexture(Texture texture)
             : this(texture.width, texture.height)
         {
         }
@@ -37,10 +37,10 @@ namespace net.puk06.ColorChanger.Models
         /// RenderTextureを内部で作成します。すでにCreateが実行されていた際は例外を吐きます。
         /// Texture2Dを渡すことで、作成時に自動的にコピーされます。
         /// </summary>
-        /// <param name="texture2D"></param>
+        /// <param name="texture"></param>
         /// <returns></returns>
         /// <exception cref="Exception"></exception>
-        public ExtendedRenderTexture Create(Texture2D texture2D = null)
+        public ExtendedRenderTexture Create(Texture texture = null)
         {
             if (_isCreated) throw new Exception("RenderTexture has already created.");
             if (_disposed) throw new Exception("RenderTexture has already disposed.");
@@ -49,7 +49,7 @@ namespace net.puk06.ColorChanger.Models
             {
                 _isCreated = true;
 
-                if (texture2D != null) Graphics.Blit(texture2D, this);
+                if (texture != null) Graphics.Blit(texture, this);
             }
             else
             {

--- a/Editor/Models/ExtendedRenderTexture.cs
+++ b/Editor/Models/ExtendedRenderTexture.cs
@@ -24,7 +24,7 @@ namespace net.puk06.ColorChanger.Models
         }
 
         /// <summary>
-        /// Texture2D のサイズの大きさの ExtendedRenderTexture を Initialize します。Createはこの時点では実行されません。
+        /// Texture のサイズの大きさの ExtendedRenderTexture を Initialize します。Createはこの時点では実行されません。
         /// 作成時、中身はコピーされません。中身をコピーしたい場合は <see cref="Create(Texture)"/> を使ってください。
         /// </summary>
         /// <param name="texture"></param>
@@ -35,7 +35,7 @@ namespace net.puk06.ColorChanger.Models
 
         /// <summary>
         /// RenderTextureを内部で作成します。すでにCreateが実行されていた際は例外を吐きます。
-        /// Texture2Dを渡すことで、作成時に自動的にコピーされます。
+        /// Textureを渡すことで、作成時に自動的にコピーされます。
         /// </summary>
         /// <param name="texture"></param>
         /// <returns></returns>

--- a/Editor/NDMF/NDMFPreview.cs
+++ b/Editor/NDMF/NDMFPreview.cs
@@ -26,7 +26,7 @@ namespace net.puk06.ColorChanger.NDMF
                     // アバター内にある全部のコンポーネント
                     var components = context.GetComponentsInChildren<ColorChangerForUnity>(avatar, true)
 #if USE_TEXTRANSTOOL
-                        .Where(component => !component.GetComponent<rs64.TexTransTool.MultiLayerImage.ExternalToolAsLayer>())
+                        .Where(component => !context.GetComponent<rs64.TexTransTool.MultiLayerImage.ExternalToolAsLayer>(component.gameObject))
                         .ToArray()
 #endif
                     ;
@@ -63,13 +63,6 @@ namespace net.puk06.ColorChanger.NDMF
                         {
                             rendererList.Add(firstComponent);
                         }
-                    }
-
-                    foreach (var component in components)
-                    {
-#if USE_TEXTRANSTOOL
-                        context.Observe(component, c => c.GetComponent<rs64.TexTransTool.MultiLayerImage.ExternalToolAsLayer>());
-#endif
                     }
 
                     // レンダラーリストは、コンポーネントによってアバター内のどれかのマテリアルテクスチャが参照されているレンダラーのリスト

--- a/Editor/NDMF/NDMFPreview.cs
+++ b/Editor/NDMF/NDMFPreview.cs
@@ -27,13 +27,14 @@ namespace net.puk06.ColorChanger.NDMF
                     var components = context.GetComponentsInChildren<ColorChangerForUnity>(avatar, true)
 #if USE_TEXTRANSTOOL
                         .Where(component => !component.GetComponent<rs64.TexTransTool.MultiLayerImage.ExternalToolAsLayer>())
+                        .ToArray()
 #endif
                     ;
                     if (components == null) continue;
 
                     // その中で参照されてる全てのテクスチャ (重複対策してあります)
                     var targetTextures = components
-                        .Select(c => c.targetTexture)
+                        .Select(c => context.Observe(c, c => c.targetTexture))
                         .Where(t => t != null)
                         .Distinct()
                         .ToArray();
@@ -66,7 +67,6 @@ namespace net.puk06.ColorChanger.NDMF
 
                     foreach (var component in components)
                     {
-                        context.Observe(component, c => c.targetTexture);
 #if USE_TEXTRANSTOOL
                         context.Observe(component, c => c.GetComponent<rs64.TexTransTool.MultiLayerImage.ExternalToolAsLayer>());
 #endif

--- a/Editor/NDMF/NDMFPreview.cs
+++ b/Editor/NDMF/NDMFPreview.cs
@@ -24,7 +24,11 @@ namespace net.puk06.ColorChanger.NDMF
                 try
                 {
                     // アバター内にある全部のコンポーネント
-                    var components = avatar.GetComponentsInChildren<ColorChangerForUnity>(true);
+                    var components = context.GetComponentsInChildren<ColorChangerForUnity>(avatar, true)
+#if USE_TEXTRANSTOOL
+                        .Where(component => !component.GetComponent<rs64.TexTransTool.MultiLayerImage.ExternalToolAsLayer>())
+#endif
+                    ;
                     if (components == null) continue;
 
                     // その中で参照されてる全てのテクスチャ (重複対策してあります)
@@ -63,6 +67,9 @@ namespace net.puk06.ColorChanger.NDMF
                     foreach (var component in components)
                     {
                         context.Observe(component, c => c.targetTexture);
+#if USE_TEXTRANSTOOL
+                        context.Observe(component, c => c.GetComponent<rs64.TexTransTool.MultiLayerImage.ExternalToolAsLayer>());
+#endif
                     }
 
                     // レンダラーリストは、コンポーネントによってアバター内のどれかのマテリアルテクスチャが参照されているレンダラーのリスト

--- a/Editor/Utils/ExternalUtils.cs
+++ b/Editor/Utils/ExternalUtils.cs
@@ -1,0 +1,23 @@
+using net.puk06.ColorChanger.Models;
+using UnityEditor;
+using UnityEngine;
+
+namespace net.puk06.ColorChanger.Utils
+{
+    [InitializeOnLoad]
+    internal static class ExternalUtils
+    {
+        static ExternalUtils()
+            => ColorChangerForUnity.action = ProcessTexture;
+
+        private static void ProcessTexture(RenderTexture renderTexture, ColorChangerForUnity component)
+        {
+            ExtendedRenderTexture originalTexture = new ExtendedRenderTexture(renderTexture)
+                .Create(renderTexture);
+
+            TextureUtils.ProcessTexture(originalTexture, renderTexture, component);
+
+            originalTexture.Dispose();
+        }
+    }
+}

--- a/Editor/Utils/ExternalUtils.cs.meta
+++ b/Editor/Utils/ExternalUtils.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8fc665c51710e4248b34a1ef08b2b893
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Utils/TextureUtils.cs
+++ b/Editor/Utils/TextureUtils.cs
@@ -79,7 +79,7 @@ namespace net.puk06.ColorChanger.Utils
                     targetTexture as Texture2D
                 );
             }
-            else if (typeof(T) == typeof(ExtendedRenderTexture))
+            else if (typeof(T) == typeof(ExtendedRenderTexture) || typeof(T) == typeof(RenderTexture))
             {
                 imageProcessor.ProcessAllPixelsGPU(
                     originalTexture as RenderTexture,

--- a/Editor/net.puk06.color-changer.Editor.asmdef
+++ b/Editor/net.puk06.color-changer.Editor.asmdef
@@ -15,6 +15,12 @@
     "precompiledReferences": [],
     "autoReferenced": false,
     "defineConstraints": [],
-    "versionDefines": [],
+    "versionDefines": [
+        {
+            "name": "net.rs64.tex-trans-tool",
+            "expression": "1.1.0-beta.3",
+            "define": "USE_TEXTRANSTOOL"
+        }
+    ],
     "noEngineReferences": false
 }

--- a/Editor/net.puk06.color-changer.Editor.asmdef
+++ b/Editor/net.puk06.color-changer.Editor.asmdef
@@ -3,7 +3,8 @@
     "rootNamespace": "",
     "references": [
         "net.puk06.color-changer.runtime",
-        "nadena.dev.ndmf"
+        "nadena.dev.ndmf",
+        "net.rs64.tex-trans-tool.runtime"
     ],
     "includePlatforms": [
         "Editor"

--- a/Runtime/ColorChangerForUnity.cs
+++ b/Runtime/ColorChangerForUnity.cs
@@ -1,12 +1,14 @@
 using UnityEngine;
 using net.puk06.ColorChanger.Models;
 using System;
-using net.rs64.TexTransTool.MultiLayerImage;
 
 namespace net.puk06.ColorChanger
 {
     [Serializable]
-    public class ColorChangerForUnity : MonoBehaviour, VRC.SDKBase.IEditorOnly, IExternalToolCanBehaveAsGrabLayerV1
+    public class ColorChangerForUnity : MonoBehaviour, VRC.SDKBase.IEditorOnly
+#if USE_TEXTRANSTOOL
+    ,net.rs64.TexTransTool.MultiLayerImage.IExternalToolCanBehaveAsGrabLayerV1
+#endif
     {
         public bool Enabled = true;
         public bool PreviewEnabled = true;

--- a/Runtime/ColorChangerForUnity.cs
+++ b/Runtime/ColorChangerForUnity.cs
@@ -1,11 +1,12 @@
 using UnityEngine;
 using net.puk06.ColorChanger.Models;
 using System;
+using net.rs64.TexTransTool.MultiLayerImage;
 
 namespace net.puk06.ColorChanger
 {
     [Serializable]
-    public class ColorChangerForUnity : MonoBehaviour, VRC.SDKBase.IEditorOnly
+    public class ColorChangerForUnity : MonoBehaviour, VRC.SDKBase.IEditorOnly, IExternalToolCanBehaveAsGrabLayerV1
     {
         public bool Enabled = true;
         public bool PreviewEnabled = true;
@@ -17,5 +18,13 @@ namespace net.puk06.ColorChanger
 
         public BalanceModeConfiguration balanceModeConfiguration = new BalanceModeConfiguration();
         public AdvancedColorConfiguration advancedColorConfiguration = new AdvancedColorConfiguration();
+
+        /// <summary>
+        /// TTTのExternalToolAsLayer用のものです。
+        /// </summary>
+        public static Action<RenderTexture, ColorChangerForUnity> action;
+
+        public void GrabBlending(RenderTexture renderTexture)
+            => action(renderTexture, this);
     }
 }

--- a/Runtime/ColorChangerForUnity.cs
+++ b/Runtime/ColorChangerForUnity.cs
@@ -7,7 +7,7 @@ namespace net.puk06.ColorChanger
     [Serializable]
     public class ColorChangerForUnity : MonoBehaviour, VRC.SDKBase.IEditorOnly
 #if USE_TEXTRANSTOOL
-    ,net.rs64.TexTransTool.MultiLayerImage.IExternalToolCanBehaveAsGrabLayerV1
+        , net.rs64.TexTransTool.MultiLayerImage.IExternalToolCanBehaveAsGrabLayerV1
 #endif
     {
         public bool Enabled = true;

--- a/Runtime/net.puk06.color-changer.Runtime.asmdef
+++ b/Runtime/net.puk06.color-changer.Runtime.asmdef
@@ -11,6 +11,12 @@
     "precompiledReferences": [],
     "autoReferenced": false,
     "defineConstraints": [],
-    "versionDefines": [],
+    "versionDefines": [
+        {
+            "name": "net.rs64.tex-trans-tool",
+            "expression": "1.1.0-beta.3",
+            "define": "USE_TEXTRANSTOOL"
+        }
+    ],
     "noEngineReferences": false
 }

--- a/Runtime/net.puk06.color-changer.Runtime.asmdef
+++ b/Runtime/net.puk06.color-changer.Runtime.asmdef
@@ -1,7 +1,9 @@
 {
     "name": "net.puk06.color-changer.runtime",
     "rootNamespace": "",
-    "references": [],
+    "references": [
+        "net.rs64.tex-trans-tool.runtime"
+    ],
     "includePlatforms": [],
     "excludePlatforms": [],
     "allowUnsafeCode": false,


### PR DESCRIPTION
TexTransToolのExternalToolAsLayerに対応しました。
Color Changer For Unityで適用されたテクスチャを、直接TexTransToolのレイヤーとして追加可能になりました。