### PR TITLE
Fix preview texture copying

### DIFF
--- a/Editor/Ndmf/RealtimePreview.cs
+++ b/Editor/Ndmf/RealtimePreview.cs
@@ -83,7 +83,7 @@ namespace net.puk06.ColorChanger.Editor.Ndmf
 
         public Task<IRenderFilterNode> Instantiate(RenderGroup group, IEnumerable<(Renderer, Renderer)> proxyPairs, ComputeContext context)
         {
-            Dictionary<Texture2D, ExtendedRenderTexture>? processedTexturesDictionary = null;
+            Dictionary<Texture2D, Texture2D>? processedTexturesDictionary = null;
             Dictionary<Renderer, Material?[]>? processedMaterialDictionary = new();
 
             try
@@ -94,25 +94,26 @@ namespace net.puk06.ColorChanger.Editor.Ndmf
                 IEnumerable<ColorChangerForUnity> enabledComponents = components.Where(x => context.ActiveInHierarchy(x.gameObject) && x.IsEnabled && x.IsPreviewEnabled);
                 Dictionary<Texture2D, ExtendedRenderTexture> processedTextures = NdmfProcessor.ProcessAllComponents(enabledComponents);
                 ObjectReferenceService.RegisterReplacements(processedTextures);
+                processedTexturesDictionary = NdmfProcessor.ConvertToTexture2DDictionary(processedTextures);
 
                 foreach ((Renderer original, Renderer proxy) in proxyPairs)
                 {
                     processedMaterialDictionary[original] = proxy.sharedMaterials.Select(mat => {
-                        Material? newMaterial = NdmfProcessor.GetProcessedMaterial(mat, processedTextures);
+                        Material? newMaterial = NdmfProcessor.GetProcessedMaterial(mat, processedTexturesDictionary);
                         if (mat != null && newMaterial != null) ObjectRegistry.RegisterReplacedObject(mat, newMaterial);
                         return newMaterial;
                     }).ToArray();
                 }
 
-                return Task.FromResult<IRenderFilterNode>(new TextureReplacerNode(processedMaterialDictionary, processedTextures.Values));
+                return Task.FromResult<IRenderFilterNode>(new TextureReplacerNode(processedMaterialDictionary));
             }
             catch (Exception ex)
             {
                 LogUtils.LogError($"Failed to instantiate.\n{ex}");
                 if (processedTexturesDictionary != null)
                 {
-                    foreach (ExtendedRenderTexture texture in processedTexturesDictionary.Values)
-                        texture.Dispose();
+                    foreach (Texture2D texture in processedTexturesDictionary.Values)
+                        Object.DestroyImmediate(texture);
                     processedTexturesDictionary.Clear();
                     processedTexturesDictionary = null;
                 }
@@ -125,21 +126,19 @@ namespace net.puk06.ColorChanger.Editor.Ndmf
                     processedMaterialDictionary.Clear();
                     processedMaterialDictionary = null;
                 }
-                return Task.FromResult<IRenderFilterNode>(new TextureReplacerNode(null, null));
+                return Task.FromResult<IRenderFilterNode>(new TextureReplacerNode(null));
             }
         }
 
         private class TextureReplacerNode : IRenderFilterNode, IDisposable
         {
-            private IEnumerable<ExtendedRenderTexture>? _processedTextures;
             private Dictionary<Renderer, Material?[]>? _processedMaterialDictionary;
 
             public RenderAspects WhatChanged { get; private set; } = RenderAspects.Texture | RenderAspects.Material;
 
-            public TextureReplacerNode(Dictionary<Renderer, Material?[]>? processedMaterialDictionary, IEnumerable<ExtendedRenderTexture>? processedTexturesDictionary)
+            public TextureReplacerNode(Dictionary<Renderer, Material?[]>? processedMaterialDictionary)
             {
                 _processedMaterialDictionary = processedMaterialDictionary;
-                _processedTextures = processedTexturesDictionary;
             }
 
             public void OnFrame(Renderer original, Renderer proxy)
@@ -159,13 +158,6 @@ namespace net.puk06.ColorChanger.Editor.Ndmf
 
             public void Dispose()
             {
-                if (_processedTextures != null)
-                {
-                    foreach (ExtendedRenderTexture texture in _processedTextures)
-                        texture.Dispose();
-                    _processedTextures = null;
-                }
-
                 if (_processedMaterialDictionary != null)
                 {
                     foreach (Material?[] materials in _processedMaterialDictionary.Values)

--- a/Editor/Ndmf/RealtimePreview.cs
+++ b/Editor/Ndmf/RealtimePreview.cs
@@ -134,7 +134,7 @@ namespace net.puk06.ColorChanger.Editor.Ndmf
             private IEnumerable<ExtendedRenderTexture>? _processedTextures;
             private Dictionary<Renderer, Material?[]>? _processedMaterialDictionary;
 
-            public RenderAspects WhatChanged { get; private set; } = RenderAspects.Texture & RenderAspects.Material;
+            public RenderAspects WhatChanged { get; private set; } = RenderAspects.Texture | RenderAspects.Material;
 
             public TextureReplacerNode(Dictionary<Renderer, Material?[]>? processedMaterialDictionary, IEnumerable<ExtendedRenderTexture>? processedTexturesDictionary)
             {


### PR DESCRIPTION
Fix for a bug where ColorChangerForUnity texture replacement loses liltoon fur-related settings in the NDMF preview.

### 概要
NDMFプレビュー時に `ColorChangerForUnity` のテクスチャ置き換えが `liltoon` のファー関連設定を失う不具合の修正を提案します。
対象バージョン：2.0.6

### 背景
テクスチャ置換機能を使用時、ビルド時は正しく置換されるが、NDMFプレビューでファー設定 `_FurVectorTex` / `_FurLengthMask` がコピーされない問題が発生していました。（モフモフのアバターに ColorChangerForUnity をつけるとツルツルになったということです）
プレビュー実装がビルド実装と異なるテクスチャ差し替え方法であることに気づき、ビルド実装に寄せたところ正常動作したため、コードを共有します。
**私自身 NDMF に熟達しているわけではありません。本PRがよくないワークアラウンドの可能性があることをご了承ください。**

### 変更内容
- プレビュー側でも `ExtendedRenderTexture` を直接マテリアルに渡すのではなく、ビルド側と同様に `Texture2D` に変換してから `GetProcessedMaterial()` へ渡す
- `TextureReplacerNode.WhatChanged` を `RenderAspects.Texture | RenderAspects.Material` に修正し、プレビュー更新の変更フラグを正しく設定。こちらは本筋ではありませんが、 `RenderAspects.Texture & RenderAspects.Material` だと常にゼロになるのではと思います。
